### PR TITLE
Fix memory leak with self retain in setImage:

### DIFF
--- a/KPCScaleToFillNSImageView.m
+++ b/KPCScaleToFillNSImageView.m
@@ -49,12 +49,13 @@
 		return;
 	}
 
+    __weak KPCScaleToFillNSImageView *weakSelf = self;
 	NSImage *scaleToFillImage = [NSImage imageWithSize:self.bounds.size
 											   flipped:NO
                                         drawingHandler:^BOOL(NSRect dstRect) {
 
                                             NSSize imageSize = [image size];
-                                            NSSize imageViewSize = self.bounds.size; // Yes, do not use dstRect.
+                                            NSSize imageViewSize = weakSelf.bounds.size; // Yes, do not use dstRect.
 
                                             NSSize newImageSize = imageSize;
 


### PR DESCRIPTION
Fairly self explanatory. The use of `self` within the image drawing block can create a memory leak/cycle. This PR fixes that.